### PR TITLE
chore: Bump version to 1.2.0

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Base version - increment these for new releases -->
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <MinorVersion>2</MinorVersion>
     <PatchVersion>0</PatchVersion>
 
     <!-- Full version is set by CI/CD workflow -->


### PR DESCRIPTION
Bump `Version.props` from 1.1.0 to 1.2.0 to correctly version the preview release. The previous preview release `v1.1.0-preview.1` was incorrectly versioned and has been deleted.