### PR TITLE
Allow HDGM .dll selection in model file filter (#55)

### DIFF
--- a/GeoMagGUI/Properties/Resources.resx
+++ b/GeoMagGUI/Properties/Resources.resx
@@ -131,7 +131,7 @@
     <value>..\documentation\README.md;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="File_Type_All_Coeff_Files" xml:space="preserve">
-    <value>All Supported Coefficient Files (*.cof;*.dat;*.dll)|*.cof;*.dat;*.dll</value>
+    <value>Coefficient Files (*.cof;*.dat)|*.cof;*.dat|HDGM DLL (*.dll)|*.dll|All Supported (*.cof;*.dat;*.dll)|*.cof;*.dat;*.dll</value>
   </data>
   <data name="Location_icon_16" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\assets\location-icon_16.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/GeoMagGUI/Properties/Resources.resx
+++ b/GeoMagGUI/Properties/Resources.resx
@@ -131,7 +131,7 @@
     <value>..\documentation\README.md;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="File_Type_All_Coeff_Files" xml:space="preserve">
-    <value>All Supported Coefficient Files (*.cof;*.dat)|*.cof;*.dat</value>
+    <value>All Supported Coefficient Files (*.cof;*.dat;*.dll)|*.cof;*.dat;*.dll</value>
   </data>
   <data name="Location_icon_16" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\assets\location-icon_16.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>


### PR DESCRIPTION
## Summary

One-line filter update so HDGM DLLs are selectable in the Add Model / Load Model dialogs.

\`\`\`diff
- All Supported Coefficient Files (*.cof;*.dat)|*.cof;*.dat
+ All Supported Coefficient Files (*.cof;*.dat;*.dll)|*.cof;*.dat;*.dll
\`\`\`

GeoMagSharp 1.6.0 already auto-detects HDGM by filename in \`GeoMag.LoadModel(string)\` — the only blocker for end-to-end HDGM use through the GUI was that .dll files were excluded from the file dialog filter.

Closes #55.

## Test plan

- [ ] Add Model → file dialog now shows .dll files alongside .cof / .dat
- [ ] Selecting hdgm2019-64.dll registers the model via HDGMModelLoader (verified via GeoMagSharp.dll v1.6.0 routing)
- [ ] Existing .cof / .dat selection still works unchanged

## Process note

Ralph Loop relaxed for this trivial scope (one-line change in a localizable resource string) per maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)