### PR TITLE
release: 1.2.0 — version bump, Directory.Build.props, GeoMagSharp 1.7.2 README refresh

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+  <!-- Single source of truth for the GeoMagGUI version.
+
+       When bumping, update **three** locations (the old-style .NET Framework
+       csproj does not auto-consume these MSBuild properties; they're declared
+       here as documentation + future-proofing for an SDK-style migration):
+
+       1. <VersionPrefix> below
+       2. [assembly: AssemblyVersion]   in GeoMagGUI/Properties/AssemblyInfo.cs
+       3. [assembly: AssemblyFileVersion] in GeoMagGUI/Properties/AssemblyInfo.cs
+       4. <ApplicationVersion>          in GeoMagGUI/GeoMagGUI.csproj
+
+       Keep all four in sync. -->
+  <PropertyGroup>
+    <VersionPrefix>1.2.0</VersionPrefix>
+  </PropertyGroup>
+</Project>

--- a/GeoMagGUI/GeoMagGUI.csproj
+++ b/GeoMagGUI/GeoMagGUI.csproj
@@ -23,7 +23,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <ApplicationVersion>1.2.0.%2a</ApplicationVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/GeoMagGUI/Properties/AssemblyInfo.cs
+++ b/GeoMagGUI/Properties/AssemblyInfo.cs
@@ -33,6 +33,10 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+// Keep these in sync with <VersionPrefix> in Directory.Build.props (single
+// source of truth). The old-style .NET Framework csproj doesn't auto-stamp
+// these from MSBuild properties — see Directory.Build.props for the
+// version-bump checklist.
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/README.md
+++ b/README.md
@@ -11,24 +11,32 @@ A C# WinForms application for calculating geomagnetic field values using spheric
 
 GeoMagSharpGUI calculates Earth's magnetic field components (declination, inclination, intensity) at any location and date using coefficient files from models like:
 
-- **IGRF** (International Geomagnetic Reference Field)
-- **WMM** (World Magnetic Model)
-- **DGRF** (Definitive Geomagnetic Reference Field)
+- **WMM** / **WMMHR** (World Magnetic Model and high-resolution variant)
+- **IGRF** / **DGRF** (International / Definitive Geomagnetic Reference Field)
 - **EMM** (Enhanced Magnetic Model)
+- **BGGM** (BGS Global Geomagnetic Model — commercial, user-supplied)
+- **HDGM** (High Definition Geomagnetic Model — Windows-only, NOAA DLL)
 
 ## Features
 
 - Calculate magnetic declination, inclination, and field intensity
 - Auto-discovery of model files in the `coefficient/` folder (`.COF`, `.DAT`, HDGM `.DLL`)
 - HDGM (High Definition Geomagnetic Model) support via NOAA-supplied DLL (Windows-only)
-- ISCWSA-based uncertainty (1-sigma) shown in the results grid
+- 1-sigma uncertainty shown in the results grid + side detail panel,
+  populated from the loaded model's native error model where one exists
+  (WMM/WMMHR Tech Report formula, HDGM per-point sigmas) with ISCWSA
+  Level 1 fallback for IGRF/DGRF/EMM/BGGM
+- Master-detail layout: values-only grid on the left, full breakdown
+  (declination, inclination, all components, σ rows, model metadata
+  chips) on the right
+- Model metadata surfaced from `ModelDescriptor` 1.7.2 fields: degree
+  chip, altitude validity row, epoch count, σ source label
 - Support for multiple coordinate input formats (Decimal Degrees, DMS)
 - GPS location integration via Windows Location Services
 - Historical calculations with date range support
 - Multiple output units (nanoTesla, Gauss)
 - Secular variation (change per year) calculations
 - Async calculation with cancellation and progress reporting
-- Export results to TXT, CSV, and JSON formats
 - User-configurable preferences
 
 ## Solution Structure
@@ -77,12 +85,12 @@ NuGet restore automatically downloads the [GeoMagSharp](https://www.nuget.org/pa
 
 ## Usage
 
-1. **Select a Magnetic Model** - Choose from available models (IGRF, WMM, etc.)
+1. **Select a Magnetic Model** - Choose from available models (WMM, WMMHR, IGRF, EMM, BGGM, HDGM)
 2. **Enter Location** - Input coordinates as decimal degrees or DMS
 3. **Set Elevation** - Enter altitude above MSL or depth below MSL
 4. **Choose Date(s)** - Select single date or date range
 5. **Calculate** - View magnetic field results in the grid
-6. **Save Results** - Export to text file if needed
+6. **Inspect a Row** - Selecting a grid row populates the side detail panel with the full breakdown (all seven components, 1-σ uncertainty per component, model metadata chips, validity range, epoch count)
 
 ## Magnetic Field Components
 


### PR DESCRIPTION
## Summary

Bumps the GUI to **1.2.0** (next stable after `v1.1.0`), introduces `Directory.Build.props` as the documented single source of truth for the version, and refreshes README to match the post-1.7.2 GUI feature set.

**Do not merge yet** — the GeoMagSharp 1.7.2 NuGet release is published (workflow #25585964158 succeeded with `Your package was pushed`) but the nuget.org flat-container index typically lags 5–15 minutes. Verify a clean restore (`dotnet restore` with cleared `~/.nuget/packages/geomagsharp/1.7.2`) succeeds before merging.

## Why version `1.2.0` and not `1.4.0+something`?

Investigation showed the prior `AssemblyVersion = 1.4.0.0` (set in old commit `f0ba6d6`, way back) was **never released**. The actual latest GitHub release tag is `v1.1.0`. A previous Claude-authored chore commit (`8d345cb`) claimed in its message "Bump GUI version to 1.3.0 in Version.props" but the commit's actual diff was only the GeoMagSharp PackageReference (1.4.0 → 1.5.0). No `Version.props` file was created. So three version surfaces drifted:

| Place | Was | Now |
|---|---|---|
| `AssemblyInfo.cs` `AssemblyVersion` | 1.4.0.0 (unreleased) | **1.2.0.0** |
| `AssemblyInfo.cs` `AssemblyFileVersion` | 1.4.0.0 | **1.2.0.0** |
| `csproj` `<ApplicationVersion>` | 1.0.0.* | **1.2.0.*** |
| `Directory.Build.props` `<VersionPrefix>` | (didn't exist) | **1.2.0** (new — single source of truth + bump checklist) |

Releasing as `v1.2.0` aligns with the existing `v1.2.0-preview.2` tag and reflects the natural increment from `v1.1.0`.

## What's in this PR

- **`Directory.Build.props`** (new): documents the single-source-of-truth intent; lists the three other places that must stay in sync until/unless the old-style csproj migrates to SDK-style.
- **`AssemblyInfo.cs`**: AssemblyVersion + AssemblyFileVersion → 1.2.0.0 with a comment pointing to `Directory.Build.props`.
- **`GeoMagGUI.csproj`**: `<ApplicationVersion>` → 1.2.0.* (Click-Once publish version).
- **`README.md`** refresh:
  - Models list now includes WMMHR, BGGM, HDGM (was IGRF/WMM/DGRF/EMM only)
  - Uncertainty bullet rewritten for the unified `GeomagneticUncertainty` shape — ISCWSA / WMM error model / HDGM per-point, not "ISCWSA-based" alone
  - Master-detail layout + 1.7.2 metadata chips/rows added to Features
  - "Export results to TXT/CSV/JSON" removed — that menu item was validation-only and was deleted in #62
  - Usage step 6 reflects the side detail panel rather than the now-removed `Save Results...` flow

## What's NOT in this PR

- GeoMagSharp PackageReference bump — already at 1.7.2 from prior PRs in this same release cycle
- Tag `v1.2.0` on `master` — will happen after promotion through preview → master, after this PR merges to development

## Reviewer checklist before merging

- [ ] `dotnet restore` succeeds against the published 1.7.2 (clear `~/.nuget/packages/geomagsharp/1.7.2` to force pull from nuget.org)
- [ ] GUI launches and shows expected metadata chips, σ source labels, etc.
- [ ] `Directory.Build.props` `<VersionPrefix>` matches `AssemblyInfo.cs` and `<ApplicationVersion>` (all `1.2.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)