### PR TITLE
fix(#59): harden AfterBuild against path-mangled coefficient artifact

### DIFF
--- a/GeoMagGUI/GeoMagGUI.csproj
+++ b/GeoMagGUI/GeoMagGUI.csproj
@@ -161,12 +161,27 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- Move NuGet-provided coefficient files into the coefficient/ subdirectory -->
+  <!-- Move NuGet-provided coefficient files into the coefficient/ subdirectory.
+       Defends against the path-mangling bug in #59 where NuGet occasionally
+       produced "coefficientWMM2025.COF" flat at $(OutputPath) instead of
+       "coefficient\WMM2025.COF" — promoting that into coefficient/ would
+       leave a mangled-name duplicate. The Exclude clauses keep flat files
+       starting with "coefficient" out of the Move; the ManglingArtifacts
+       step deletes them with a build warning so the cause stays visible.
+
+       Note on MSBuild glob semantics: $(OutputPath)coefficient*.COF matches
+       a flat file at $(OutputPath) whose name starts with "coefficient"; it
+       does NOT match $(OutputPath)\coefficient\*.COF (legit files inside the
+       coefficient subdir), because the * wildcard doesn't cross path
+       separators. -->
   <Target Name="AfterBuild">
     <ItemGroup>
-      <CofFiles Include="$(OutputPath)*.COF" />
-      <DatFiles Include="$(OutputPath)*.DAT" />
+      <CofFiles Include="$(OutputPath)*.COF" Exclude="$(OutputPath)coefficient*.COF" />
+      <DatFiles Include="$(OutputPath)*.DAT" Exclude="$(OutputPath)coefficient*.DAT" />
+      <ManglingArtifacts Include="$(OutputPath)coefficient*.COF;$(OutputPath)coefficient*.DAT" />
     </ItemGroup>
+    <Warning Text="AfterBuild: removing path-mangled coefficient artifact '%(ManglingArtifacts.Filename)%(ManglingArtifacts.Extension)' (#59 defensive guard; likely a NuGet packaging quirk for this version)" Condition="'@(ManglingArtifacts)' != ''" />
+    <Delete Files="@(ManglingArtifacts)" Condition="'@(ManglingArtifacts)' != ''" />
     <MakeDir Directories="$(OutputPath)coefficient" Condition="'@(CofFiles)' != '' Or '@(DatFiles)' != ''" />
     <Move SourceFiles="@(CofFiles)" DestinationFolder="$(OutputPath)coefficient" OverwriteReadOnlyFiles="true" Condition="'@(CofFiles)' != ''" />
     <Move SourceFiles="@(DatFiles)" DestinationFolder="$(OutputPath)coefficient" OverwriteReadOnlyFiles="true" Condition="'@(DatFiles)' != ''" />


### PR DESCRIPTION
## Summary

Hardens the `AfterBuild` target in `GeoMagGUI.csproj` against the path-mangled coefficient artifact pattern documented in #59. Two-layer defense:

1. **Exclude** flat `$(OutputPath)coefficient*.{COF,DAT}` from the items the Move task picks up. Files inside the `coefficient/` subdir are unaffected — the `*` wildcard doesn't cross path separators in MSBuild item globs.
2. **Detect + delete** any such mangled artifact at `$(OutputPath)` with a build `Warning` so the cause stays visible if it ever returns.

## Why it's a defensive fix rather than addressing the cause

The mangled artifact (e.g. `coefficientWMM2025.COF` flat at `$(OutputPath)`) **does not reproduce on the current 1.7.2 package layout.** Verified via clean rebuilds with package versions 1.7.0 and 1.7.2 — both correctly place `coefficient/X.COF` files via the package's `Link` metadata + `PackageCopyToOutput=true`, with nothing flat at `$(OutputPath)`.

That doesn't mean it can't return. The original `AfterBuild` glob (`$(OutputPath)*.COF`) was loose enough that if a future NuGet packaging quirk reintroduced the mangled flat name, it would get faithfully promoted into `coefficient/` with the mangled name preserved. The defensive harden costs ~10 lines of MSBuild and prevents that.

## Verification

- **Normal clean build**: produces the expected 6 `.COF` files in `bin/Debug/coefficient/`, no mangled duplicates.
- **Manually planted mangled artifact**: created `bin/Debug/coefficientWMM2025.COF` (simulating the bug), rebuilt → the artifact was deleted and `bin/Debug/coefficient/` was clean (no `coefficientWMM2025.COF` inside).

## Notes

- The MSBuild `*` wildcard in item globs matches characters within a single path segment; `$(OutputPath)coefficient*.COF` matches a flat file at `$(OutputPath)` starting with "coefficient" but does NOT match `$(OutputPath)coefficient/X.COF` (inside the subdir). Comments in the target document this for future readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)